### PR TITLE
Refactor Modal with Floating UI and smoother transitions

### DIFF
--- a/docs/Modal.md
+++ b/docs/Modal.md
@@ -137,10 +137,10 @@ const App = () => {
 
 ## Behavior Notes
 
-- **Rendering:** When `isOpen` is false, the component returns `null` (nothing in the DOM).
+- **Rendering:** The modal mounts when `isOpen` is true and unmounts shortly after close so the exit transition can finish.
 - **Close:** onClose is called when the user clicks the X button (if showCloseButton), the overlay (if closeOnOverlayClick), or Escape (if closeOnEscape). Footer buttons do not auto-close; call onClose in their handlers if desired.
-- **Body scroll:** When open, `document.body.style.overflow` is set to `"hidden"`; restored on close.
-- **Focus:** On open, focus moves to the modal panel (ref + tabIndex={-1}); on close, focus returns to the previously focused element.
+- **Body scroll:** Body scroll is locked while open and restored when dismissed.
+- **Focus:** Focus is trapped while open and returned to the previously focused element on close.
 - **ARIA:** The overlay has `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` pointing to the title when present.
 - **Spacing:** `margin` accepts a full class string (e.g. "m-0") or an array of spacing suffixes; the component uses `getSpacingClass` with prefix `m-`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cleanplate",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "CleanPlate - A Headless React UI Framework",
   "files": [
     "dist",

--- a/src/components/icon/material-icon-names.ts
+++ b/src/components/icon/material-icon-names.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on: 2026-05-19T01:01:31.547Z
+// Generated on: 2026-05-21T02:22:22.292Z
 // Total icons: 4250
 
 /**

--- a/src/components/modal/Modal.module.scss
+++ b/src/components/modal/Modal.module.scss
@@ -10,8 +10,14 @@
   justify-content: center;
   z-index: 1000;
   opacity: 0;
-  pointer-events: none;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
   padding: var(--space-4);
+
+  &.overlay-open {
+    opacity: 1;
+    visibility: visible;
+  }
 }
 
 .modal {
@@ -23,8 +29,13 @@
   width: 100%;
   display: flex;
   flex-direction: column;
+  transform: scale(0.9) translateY(-20px);
+  transition: transform 0.3s ease;
   outline: none;
-  will-change: transform, opacity;
+
+  &.open {
+    transform: scale(1) translateY(0);
+  }
 
   &.small {
     max-width: var(--length-small);
@@ -158,6 +169,29 @@
   min-width: 80px;
 }
 
+// Animation keyframes
+@keyframes modal-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes modal-fade-out {
+  from {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.9) translateY(-20px);
+  }
+}
+
 // Responsive design
 @media (max-width: 768px) {
   .overlay {
@@ -234,11 +268,6 @@
   }
 }
 
-// Focus management
-.modal:focus {
-  outline: none;
-}
-
 // High contrast mode support
 @media (prefers-contrast: high) {
   .overlay {
@@ -251,18 +280,5 @@
 
   .header {
     border-bottom-color: var(--black);
-  }
-}
-
-// Reduced motion support
-@media (prefers-reduced-motion: reduce) {
-  .overlay,
-  .modal,
-  .close-button {
-    transition: none;
-  }
-
-  .modal {
-    transform: none;
   }
 }

--- a/src/components/modal/Modal.module.scss
+++ b/src/components/modal/Modal.module.scss
@@ -10,13 +10,13 @@
   justify-content: center;
   z-index: 1000;
   opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
+  pointer-events: none;
+  transition: opacity 240ms cubic-bezier(0.2, 0.9, 0.2, 1);
   padding: var(--space-4);
 
   &.overlay-open {
     opacity: 1;
-    visibility: visible;
+    pointer-events: auto;
   }
 }
 
@@ -29,13 +29,8 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  transform: scale(0.9) translateY(-20px);
-  transition: transform 0.3s ease;
   outline: none;
-
-  &.open {
-    transform: scale(1) translateY(0);
-  }
+  will-change: transform, opacity;
 
   &.small {
     max-width: var(--length-small);
@@ -167,29 +162,6 @@
 
 .footer-button {
   min-width: 80px;
-}
-
-// Animation keyframes
-@keyframes modal-fade-in {
-  from {
-    opacity: 0;
-    transform: scale(0.9) translateY(-20px);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-  }
-}
-
-@keyframes modal-fade-out {
-  from {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-  }
-  to {
-    opacity: 0;
-    transform: scale(0.9) translateY(-20px);
-  }
 }
 
 // Responsive design

--- a/src/components/modal/Modal.module.scss
+++ b/src/components/modal/Modal.module.scss
@@ -29,13 +29,8 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  transform: scale(0.9) translateY(-20px);
-  transition: transform 0.3s ease;
   outline: none;
-
-  &.open {
-    transform: scale(1) translateY(0);
-  }
+  will-change: transform, opacity;
 
   &.small {
     max-width: var(--length-small);
@@ -169,29 +164,6 @@
   min-width: 80px;
 }
 
-// Animation keyframes
-@keyframes modal-fade-in {
-  from {
-    opacity: 0;
-    transform: scale(0.9) translateY(-20px);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-  }
-}
-
-@keyframes modal-fade-out {
-  from {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-  }
-  to {
-    opacity: 0;
-    transform: scale(0.9) translateY(-20px);
-  }
-}
-
 // Responsive design
 @media (max-width: 768px) {
   .overlay {
@@ -268,6 +240,11 @@
   }
 }
 
+// Focus management
+.modal:focus {
+  outline: none;
+}
+
 // High contrast mode support
 @media (prefers-contrast: high) {
   .overlay {
@@ -280,5 +257,13 @@
 
   .header {
     border-bottom-color: var(--black);
+  }
+}
+
+// Reduced motion support
+@media (prefers-reduced-motion: reduce) {
+  .overlay,
+  .close-button {
+    transition: none;
   }
 }

--- a/src/components/modal/Modal.module.scss
+++ b/src/components/modal/Modal.module.scss
@@ -11,13 +11,7 @@
   z-index: 1000;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 240ms cubic-bezier(0.2, 0.9, 0.2, 1);
   padding: var(--space-4);
-
-  &.overlay-open {
-    opacity: 1;
-    pointer-events: auto;
-  }
 }
 
 .modal {

--- a/src/components/modal/Modal.test.tsx
+++ b/src/components/modal/Modal.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitForElementToBeRemoved } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import Modal from "./Modal";
+
+describe("Modal", () => {
+  it("calls onClose from the close button", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <Modal isOpen onClose={onClose} title="Settings">
+        Body
+      </Modal>
+    );
+
+    await user.click(screen.getByRole("button", { name: /close modal/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape only when closeOnEscape is enabled", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <Modal isOpen onClose={onClose} title="Escape Enabled">
+        Body
+      </Modal>
+    );
+
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Modal isOpen onClose={onClose} closeOnEscape={false} title="Escape Disabled">
+        Body
+      </Modal>
+    );
+
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on outside click only when closeOnOverlayClick is enabled", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <Modal isOpen onClose={onClose} title="Overlay Enabled">
+        Body
+      </Modal>
+    );
+
+    await user.click(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Modal
+        isOpen
+        onClose={onClose}
+        closeOnOverlayClick={false}
+        title="Overlay Disabled"
+      >
+        Body
+      </Modal>
+    );
+
+    await user.click(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the modal mounted briefly to allow close transition", async () => {
+    const { rerender } = render(
+      <Modal isOpen title="Transition">
+        Body
+      </Modal>
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    rerender(
+      <Modal isOpen={false} title="Transition">
+        Body
+      </Modal>
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
+  });
+});

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -46,25 +46,6 @@ const MODAL_TRANSITION_CONFIG = {
   },
 };
 
-const OVERLAY_TRANSITION_CONFIG = {
-  duration: {
-    open: 280,
-    close: 260,
-  },
-  initial: {
-    opacity: 0,
-  },
-  open: {
-    opacity: 1,
-  },
-  close: {
-    opacity: 0,
-  },
-  common: {
-    transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
-  },
-};
-
 export interface ModalProps {
   /** Modal content */
   children: React.ReactNode;
@@ -133,11 +114,6 @@ const Modal: React.FC<ModalProps> = ({
     MODAL_TRANSITION_CONFIG
   );
 
-  const { styles: overlayTransitionStyles } = useTransitionStyles(
-    context,
-    OVERLAY_TRANSITION_CONFIG
-  );
-
   const dismiss = useDismiss(context, {
     outsidePress: closeOnOverlayClick,
     outsidePressEvent: "pointerdown",
@@ -155,7 +131,13 @@ const Modal: React.FC<ModalProps> = ({
     className
   );
 
-  const overlayClasses = getClassNames(styles["overlay"], overlayClassName);
+  const overlayClasses = getClassNames(
+    styles["overlay"],
+    {
+      [styles["overlay-open"]]: isOpen,
+    },
+    overlayClassName
+  );
 
   const contentClasses = getClassNames(
     styles["content"],
@@ -175,10 +157,6 @@ const Modal: React.FC<ModalProps> = ({
       <FloatingOverlay
         lockScroll
         className={overlayClasses}
-        style={{
-          ...overlayTransitionStyles,
-          pointerEvents: isOpen ? "auto" : "none",
-        }}
       >
         <FloatingFocusManager context={context} modal returnFocus>
           <div

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -87,14 +87,14 @@ const Modal: React.FC<ModalProps> = ({
     },
   });
 
-  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
+  const { isMounted, styles: modalTransitionStyles } = useTransitionStyles(context, {
     duration: {
-      open: 240,
-      close: 180,
+      open: 320,
+      close: 200,
     },
     initial: {
       opacity: 0,
-      transform: "translateY(-12px) scale(0.97)",
+      transform: "translateY(28px) scale(0.94)",
     },
     open: {
       opacity: 1,
@@ -102,7 +102,29 @@ const Modal: React.FC<ModalProps> = ({
     },
     close: {
       opacity: 0,
-      transform: "translateY(-8px) scale(0.98)",
+      transform: "translateY(10px) scale(0.97)",
+    },
+    common: {
+      transitionTimingFunction: "cubic-bezier(0.16, 1, 0.3, 1)",
+    },
+  });
+
+  const { styles: overlayTransitionStyles } = useTransitionStyles(context, {
+    duration: {
+      open: 280,
+      close: 180,
+    },
+    initial: {
+      opacity: 0,
+    },
+    open: {
+      opacity: 1,
+    },
+    close: {
+      opacity: 0,
+    },
+    common: {
+      transitionTimingFunction: "cubic-bezier(0.2, 0.9, 0.2, 1)",
     },
   });
 
@@ -123,13 +145,7 @@ const Modal: React.FC<ModalProps> = ({
     className
   );
 
-  const overlayClasses = getClassNames(
-    styles["overlay"],
-    {
-      [styles["overlay-open"]]: isOpen,
-    },
-    overlayClassName
-  );
+  const overlayClasses = getClassNames(styles["overlay"], overlayClassName);
 
   const contentClasses = getClassNames(
     styles["content"],
@@ -149,13 +165,16 @@ const Modal: React.FC<ModalProps> = ({
       <FloatingOverlay
         lockScroll
         className={overlayClasses}
-        style={{ opacity: isOpen ? 1 : 0 }}
+        style={{
+          ...overlayTransitionStyles,
+          pointerEvents: isOpen ? "auto" : "none",
+        }}
       >
         <FloatingFocusManager context={context} modal returnFocus>
           <div
             ref={refs.setFloating}
             className={modalClasses}
-            style={transitionStyles}
+            style={modalTransitionStyles}
             {...getFloatingProps({
               "aria-modal": "true",
               "aria-labelledby": title ? titleId : undefined,

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -90,7 +90,7 @@ const Modal: React.FC<ModalProps> = ({
   const { isMounted, styles: modalTransitionStyles } = useTransitionStyles(context, {
     duration: {
       open: 320,
-      close: 200,
+      close: 320,
     },
     initial: {
       opacity: 0,
@@ -102,7 +102,8 @@ const Modal: React.FC<ModalProps> = ({
     },
     close: {
       opacity: 0,
-      transform: "translateY(10px) scale(0.97)",
+      transform: "translateY(44px) scale(0.9)",
+      filter: "blur(2px)",
     },
     common: {
       transitionTimingFunction: "cubic-bezier(0.16, 1, 0.3, 1)",
@@ -112,7 +113,7 @@ const Modal: React.FC<ModalProps> = ({
   const { styles: overlayTransitionStyles } = useTransitionStyles(context, {
     duration: {
       open: 280,
-      close: 180,
+      close: 260,
     },
     initial: {
       opacity: 0,
@@ -124,7 +125,7 @@ const Modal: React.FC<ModalProps> = ({
       opacity: 0,
     },
     common: {
-      transitionTimingFunction: "cubic-bezier(0.2, 0.9, 0.2, 1)",
+      transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
     },
   });
 

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -24,6 +24,47 @@ export type SpacingOption = (typeof SPACING_OPTIONS)[number];
 
 export type ModalMargin = string | SpacingOption[];
 
+const MODAL_TRANSITION_CONFIG = {
+  duration: {
+    open: 320,
+    close: 320,
+  },
+  initial: {
+    opacity: 0,
+    transform: "translateY(28px) scale(0.94)",
+  },
+  open: {
+    opacity: 1,
+    transform: "translateY(0) scale(1)",
+  },
+  close: {
+    opacity: 0,
+    transform: "translateY(44px) scale(0.9)",
+  },
+  common: {
+    transitionTimingFunction: "cubic-bezier(0.16, 1, 0.3, 1)",
+  },
+};
+
+const OVERLAY_TRANSITION_CONFIG = {
+  duration: {
+    open: 280,
+    close: 260,
+  },
+  initial: {
+    opacity: 0,
+  },
+  open: {
+    opacity: 1,
+  },
+  close: {
+    opacity: 0,
+  },
+  common: {
+    transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
+  },
+};
+
 export interface ModalProps {
   /** Modal content */
   children: React.ReactNode;
@@ -87,47 +128,15 @@ const Modal: React.FC<ModalProps> = ({
     },
   });
 
-  const { isMounted, styles: modalTransitionStyles } = useTransitionStyles(context, {
-    duration: {
-      open: 320,
-      close: 320,
-    },
-    initial: {
-      opacity: 0,
-      transform: "translateY(28px) scale(0.94)",
-    },
-    open: {
-      opacity: 1,
-      transform: "translateY(0) scale(1)",
-    },
-    close: {
-      opacity: 0,
-      transform: "translateY(44px) scale(0.9)",
-      filter: "blur(2px)",
-    },
-    common: {
-      transitionTimingFunction: "cubic-bezier(0.16, 1, 0.3, 1)",
-    },
-  });
+  const { isMounted, styles: modalTransitionStyles } = useTransitionStyles(
+    context,
+    MODAL_TRANSITION_CONFIG
+  );
 
-  const { styles: overlayTransitionStyles } = useTransitionStyles(context, {
-    duration: {
-      open: 280,
-      close: 260,
-    },
-    initial: {
-      opacity: 0,
-    },
-    open: {
-      opacity: 1,
-    },
-    close: {
-      opacity: 0,
-    },
-    common: {
-      transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
-    },
-  });
+  const { styles: overlayTransitionStyles } = useTransitionStyles(
+    context,
+    OVERLAY_TRANSITION_CONFIG
+  );
 
   const dismiss = useDismiss(context, {
     outsidePress: closeOnOverlayClick,

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,4 +1,14 @@
-import React, { useEffect, useRef } from "react";
+import React, { useId } from "react";
+import {
+  FloatingFocusManager,
+  FloatingOverlay,
+  FloatingPortal,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole,
+  useTransitionStyles,
+} from "@floating-ui/react";
 import Icon from "../icon";
 import Typography from "../typography";
 import Button from "../button";
@@ -67,17 +77,48 @@ const Modal: React.FC<ModalProps> = ({
   secondaryButtonLabel = "",
   onSecondaryButtonClick,
 }) => {
-  const modalRef = useRef<HTMLDivElement>(null);
-  const previousActiveElement = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const { refs, context } = useFloating({
+    open: isOpen,
+    onOpenChange: (nextOpen) => {
+      if (!nextOpen && isOpen) {
+        onClose?.();
+      }
+    },
+  });
+
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
+    duration: {
+      open: 240,
+      close: 180,
+    },
+    initial: {
+      opacity: 0,
+      transform: "translateY(-12px) scale(0.97)",
+    },
+    open: {
+      opacity: 1,
+      transform: "translateY(0) scale(1)",
+    },
+    close: {
+      opacity: 0,
+      transform: "translateY(-8px) scale(0.98)",
+    },
+  });
+
+  const dismiss = useDismiss(context, {
+    outsidePress: closeOnOverlayClick,
+    outsidePressEvent: "pointerdown",
+    escapeKey: closeOnEscape,
+  });
+  const role = useRole(context, { role: "dialog" });
+  const { getFloatingProps } = useInteractions([dismiss, role]);
 
   const marginClass = getSpacingClass(margin, utilStyles, "m");
 
   const modalClasses = getClassNames(
     styles["modal"],
     styles[size],
-    {
-      [styles["open"]]: isOpen,
-    },
     marginClass,
     className
   );
@@ -95,127 +136,88 @@ const Modal: React.FC<ModalProps> = ({
     contentClassName
   );
 
-  // Handle escape key
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (closeOnEscape && e.key === "Escape" && isOpen) {
-        onClose?.();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener("keydown", handleEscape);
-      // Store the previously focused element
-      previousActiveElement.current = document.activeElement as HTMLElement | null;
-      // Focus the modal
-      modalRef.current?.focus();
-    }
-
-    return () => {
-      document.removeEventListener("keydown", handleEscape);
-      // Restore focus to the previously focused element
-      if (previousActiveElement.current) {
-        previousActiveElement.current.focus();
-      }
-    };
-  }, [isOpen, closeOnEscape, onClose]);
-
-  // Handle body scroll lock
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "unset";
-    }
-
-    return () => {
-      document.body.style.overflow = "unset";
-    };
-  }, [isOpen]);
-
-  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (closeOnOverlayClick && e.target === e.currentTarget) {
-      onClose?.();
-    }
-  };
-
   const handleClose = () => {
     onClose?.();
   };
 
-  if (!isOpen) {
+  if (!isMounted) {
     return null;
   }
 
   return (
-    <div
-      className={overlayClasses}
-      onClick={handleOverlayClick}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={title ? "modal-title" : undefined}
-    >
-      <div
-        ref={modalRef}
-        className={modalClasses}
-        tabIndex={-1}
-        onClick={(e) => e.stopPropagation()}
+    <FloatingPortal>
+      <FloatingOverlay
+        lockScroll
+        className={overlayClasses}
+        style={{ opacity: isOpen ? 1 : 0 }}
       >
-        <div className={contentClasses}>
-          {(title || showCloseButton) && (
-            <div className={styles["header"]}>
-              {title && (
-                <Typography
-                  variant="h2"
-                  id="modal-title"
-                  className={styles["title"]}
-                >
-                  {title}
-                </Typography>
+        <FloatingFocusManager context={context} modal returnFocus>
+          <div
+            ref={refs.setFloating}
+            className={modalClasses}
+            style={transitionStyles}
+            {...getFloatingProps({
+              "aria-modal": "true",
+              "aria-labelledby": title ? titleId : undefined,
+            })}
+          >
+            <div className={contentClasses}>
+              {(title || showCloseButton) && (
+                <div className={styles["header"]}>
+                  {title && (
+                    <Typography
+                      variant="h2"
+                      id={titleId}
+                      className={styles["title"]}
+                    >
+                      {title}
+                    </Typography>
+                  )}
+                  {showCloseButton && (
+                    <Button
+                      variant="icon"
+                      size="small"
+                      onClick={handleClose}
+                      className={styles["close-button"]}
+                      aria-label="Close modal"
+                    >
+                      <Icon name="close" size="small" />
+                    </Button>
+                  )}
+                </div>
               )}
-              {showCloseButton && (
-                <Button
-                  variant="icon"
-                  size="small"
-                  onClick={handleClose}
-                  className={styles["close-button"]}
-                  aria-label="Close modal"
-                >
-                  <Icon name="close" size="small" />
-                </Button>
+              <div className={styles["body"]}>
+                {children}
+              </div>
+              {(primaryButtonLabel || secondaryButtonLabel) && (
+                <div className={styles["footer"]}>
+                  {secondaryButtonLabel && (
+                    <Button
+                      variant="outline"
+                      size="medium"
+                      onClick={onSecondaryButtonClick}
+                      className={styles["footer-button"]}
+                    >
+                      {secondaryButtonLabel}
+                    </Button>
+                  )}
+                  {primaryButtonLabel && (
+                    <Button
+                      variant="solid"
+                      size="medium"
+                      onClick={onPrimaryButtonClick}
+                      className={styles["footer-button"]}
+                    >
+                      {primaryButtonLabel}
+                    </Button>
+                  )}
+                </div>
               )}
             </div>
-          )}
-          <div className={styles["body"]}>
-            {children}
           </div>
-          {(primaryButtonLabel || secondaryButtonLabel) && (
-            <div className={styles["footer"]}>
-              {secondaryButtonLabel && (
-                <Button
-                  variant="outline"
-                  size="medium"
-                  onClick={onSecondaryButtonClick}
-                  className={styles["footer-button"]}
-                >
-                  {secondaryButtonLabel}
-                </Button>
-              )}
-              {primaryButtonLabel && (
-                <Button
-                  variant="solid"
-                  size="medium"
-                  onClick={onPrimaryButtonClick}
-                  className={styles["footer-button"]}
-                >
-                  {primaryButtonLabel}
-                </Button>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+        </FloatingFocusManager>
+      </FloatingOverlay>
+    </FloatingPortal>
   );
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- refactored `Modal` internals to use Floating UI primitives (`FloatingPortal`, `FloatingOverlay`, `FloatingFocusManager`, dismiss and role interactions)
- preserved existing public `ModalProps` API and close behavior options (`closeOnEscape`, `closeOnOverlayClick`, close button, action buttons)
- added smoother open/close transitions using Floating UI transition styles and retained exit mount for close animation
- updated modal behavior docs and added modal tests for close interactions and transition unmount behavior
- follow-up tuning based on review feedback:
  - made **close transition** clearly noticeable by increasing exit duration and strengthening dismiss motion
  - slowed overlay fade-out timing to better match modal dismissal
- latest stability/performance refinement:
  - fixed modal opening visibility regression by restoring class-driven overlay visibility state (`overlay-open`)
  - removed duplicated overlay transition logic from JS (overlay transitions are CSS-only now)
  - kept modal panel transition as JS-only (`useTransitionStyles`) to avoid split ownership
  - removed dead/unused modal keyframe and transform transition declarations from SCSS
  - removed expensive close `blur` animation from previous iteration

## Verification
- `npx vitest run --config vitest.modal.config.mts` (passes: `src/components/modal/Modal.test.tsx`, 4 tests)
- `npm run type-check` (passes)

## Notes
- project Vitest config currently has `include: []`, so an explicit temporary config was used only for executing the modal test and then removed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e88cc42-acc1-4c24-93ec-5249141049fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e88cc42-acc1-4c24-93ec-5249141049fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

